### PR TITLE
feat: add bddStep before/after step hook

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -374,12 +374,14 @@ Available events:
 * `event.suite.before(suite)` - *async* before a suite
 * `event.suite.after(suite)` - *async* after a suite
 * `event.step.before(step)` - *async* when the step is scheduled for execution
-* `event.step.after(step)`- *async* after a step
+* `event.step.after(step)` - *async* after a step
 * `event.step.started(step)` - *sync* when step starts.
 * `event.step.passed(step)` - *sync* when step passed.
 * `event.step.failed(step, err)` - *sync* when step failed.
 * `event.step.finished(step)` - *sync* when step finishes.
 * `event.step.comment(step)` - *sync* fired for comments like `I.say`.
+* `event.bddStep.before(bddStep)` - *async* when the gherkin step is scheduled for execution
+* `event.bddStep.after(bddStep)` - *async* after a gherkin step
 * `event.all.before` - before running tests
 * `event.all.after` - after running tests
 * `event.all.result` - when results are printed

--- a/lib/event.js
+++ b/lib/event.js
@@ -80,6 +80,17 @@ module.exports = {
    * @type {object}
    * @constant
    * @inner
+   * @property {'suite.before'} before
+   * @property {'suite.after'} after
+   */
+  bddStep: {
+    before: 'bddStep.before',
+    after: 'bddStep.after',
+  },
+  /**
+   * @type {object}
+   * @constant
+   * @inner
    * @property {'global.before'} before
    * @property {'global.after'} after
    * @property {'global.result'} result

--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -29,6 +29,7 @@ module.exports = (text) => {
 
   const runSteps = async (steps) => {
     for (const step of steps) {
+      event.emit(event.bddStep.before, step);
       const metaStep = new Step.MetaStep(null, step.text);
       metaStep.actor = step.keyword.trim();
       const setMetaStep = (step) => {
@@ -50,6 +51,7 @@ module.exports = (text) => {
       } finally {
         event.dispatcher.removeListener(event.step.before, setMetaStep);
       }
+      event.emit(event.bddStep.after, step);
     }
   };
 

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -11,6 +11,7 @@ const run = require('../../lib/interfaces/gherkin');
 const recorder = require('../../lib/recorder');
 const container = require('../../lib/container');
 const actor = require('../../lib/actor');
+const event = require('../../lib/event');
 
 const text = `
   Feature: checkout process
@@ -168,6 +169,25 @@ describe('BDD', () => {
     assert.equal('bird', fn.params[0]);
   });
 
+  it('should produce step events', (done) => {
+    const text = `
+    Feature: Emit step event
+
+      Scenario:
+        Then I emit step events
+    `;
+    Then('I emit step events', () => {});
+    let listeners = 0;
+    event.dispatcher.addListener(event.bddStep.before, () => listeners++);
+    event.dispatcher.addListener(event.bddStep.after, () => listeners++);
+
+    const suite = run(text);
+    suite.tests[0].fn(() => {
+      listeners.should.eql(2);
+      done();
+    });
+  });
+
   it('should use shortened form for step definitions', () => {
     let fn;
     Given('I am a {word}', params => params[0]);
@@ -214,7 +234,7 @@ describe('BDD', () => {
       Given I have product with price <price>$ in my cart
       And discount is 10 %
       Then I should see price is "<total>" $
-      
+
       Examples:
         | price | total |
         | 10    | 9     |


### PR DESCRIPTION
## Motivation/Description of the PR
I was looking for a way to create a better BDD reporter but could not get a hook to a bdd steps. This adds a way to hook before/after a bdd step. Hope I did not mess this up as this is my first try here.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [X] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [X] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
