### PR TITLE
docs: fix typo in commands.md

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -214,7 +214,7 @@ npx codeceptjs def --config path/to/codecept.json
 
 After doing that IDE should provide autocompletion for `I` object inside `Scenario` and `within` blocks.
 
-Add optional parameter `output` (or shortcat `-o`), if you want to place your definition file in specific folder:
+Add optional parameter `output` (or shortcut `-o`), if you want to place your definition file in specific folder:
 
 ```sh
 npx codeceptjs def --output ./tests/typings


### PR DESCRIPTION
## Motivation/Description of the PR
Just typo fix

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

