### PR TITLE
Fixed waitNumberOfVisibleElements for Webdriver

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2133,6 +2133,7 @@ class WebDriver extends Helper {
         let selected = await forEachAsync(res, async el => el.isDisplayed());
 
         if (!Array.isArray(selected)) selected = [selected];
+        selected = selected.filter(val => val === true);
         return selected.length === num;
       }, aSec * 1000, `The number of elements (${new Locator(locator)}) is not ${num} after ${aSec} sec`);
     }
@@ -2142,6 +2143,7 @@ class WebDriver extends Helper {
       let selected = await forEachAsync(res, async el => el.isDisplayed());
 
       if (!Array.isArray(selected)) selected = [selected];
+      selected = selected.filter(val => val === true);
       return selected.length === num;
     }, { timeout: aSec * 1000, timeoutMsg: `The number of elements (${new Locator(locator)}) is not ${num} after ${aSec} sec` });
   }

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1583,6 +1583,7 @@ class WebDriverIO extends Helper {
       let selected = await forEachAsync(res.value, async el => this.browser.elementIdDisplayed(el.ELEMENT));
 
       if (!Array.isArray(selected)) selected = [selected];
+      selected = selected.filter(val => val === true);
       return selected.length === num;
     }, aSec * 1000, `The number of elements (${JSON.stringify(locator)}) is not ${num} after ${aSec} sec`);
   }


### PR DESCRIPTION
## Motivation/Description of the PR
`waitNumberOfVisibleElements` is broken in WebDriver helpers

**Usecase:** 
When a locator returns 2 elements with 1 visible and other is not ,
Calling `I.waitNumberOfVisibleElements(locator,1)` fails everytime. 
The root cause is that the helper functions get an array of visibility booleans but does not filter them by value `true` 

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
