### PR TITLE
Fix android native locator support for appium helper

### DIFF
--- a/docs/detox.md
+++ b/docs/detox.md
@@ -179,7 +179,7 @@ If element differs on on iOS and Android you can use **cross platform locators**
 ```js
 // locate element by text on Android
 // locate element by accessibility id on iOS
-I.click({ andropermalink: /'Start', ios: '~start' });
+I.click({ android: /'Start', ios: '~start' });
 ```
 
 When application behavior differs on Android and iOS use platform-specific actions:
@@ -207,7 +207,7 @@ Scenario('save in application', (I) => {
   I.fillField('#text', 'a new text');
   I.see('a new text', '#textValue');
   I.dontSeeElement('#createdAndVisibleText');
-  I.click({ ios: '#GoButton', andropermalink: /'Button' });
+  I.click({ ios: '#GoButton', android: /'Button' });
   I.waitForElement('#createdAndVisibleText', 20);
   I.seeElement('#createdAndVisibleText');
   I.runOnAndroid(() => {

--- a/docs/mobile-react-native-locators.md
+++ b/docs/mobile-react-native-locators.md
@@ -46,14 +46,14 @@ You could do it just by changing `automationName` in the `helpers` section of th
 ```
 Then you could locate components using XPath expression:
 ```js
-I.tap({andropermalink: /'//*[@view-tag="someButton"]', ios: '~someButton'})
+I.tap({android: /'//*[@view-tag="someButton"]', ios: '~someButton'})
 ```
 This way test would work for both platforms without any changes in code.
 To simplify things further you could write a helper function:
 ```js
 function tid(id) {
   return {
-    andropermalink: /`//*[@view-tag="${id}"]`,
+    android: /`//*[@view-tag="${id}"]`,
     ios: '~' + id
   }
 }

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -19,7 +19,7 @@ I.see('davert@codecept.io', '~email of the customer'));
 I.clearField('~email of the customer'));
 I.dontSee('Nothing special', '~email of the customer'));
 I.seeElement({
-  andropermalink: /'android.widget.Button',
+  android: /'android.widget.Button',
   ios: '//UIAApplication[1]/UIAWindow[1]/UIAButton[1]'
 });
 ```
@@ -262,7 +262,7 @@ It is often happen that mobile applications behave similarly on different platfo
 CodeceptJS provides a way to specify different locators for Android and iOS platforms:
 
 ```js
-I.click({andropermalink: /'//android.widget.Button', ios: '//UIAApplication[1]/UIAWindow[1]/UIAButton[1]'});
+I.click({android: /'//android.widget.Button', ios: '//UIAApplication[1]/UIAWindow[1]/UIAButton[1]'});
 ```
 
 In case some code should be executed on one platform and ignored on others use `runOnAndroid` and `runOnIOS` methods:

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -1524,7 +1524,7 @@ function parseLocator(locator) {
         return parseLocator.call(this, locator.android);
       }
       // The locator is an Android DataMatcher or ViewMatcher locator so return as is
-      return locator;
+      return locator.android;
     }
 
     if (locator.ios && this.platform === 'ios') {

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -136,9 +136,7 @@ class Appium extends Webdriver {
     this.isRunning = false;
 
     webdriverio = requireg('webdriverio');
-    !webdriverio.VERSION || webdriverio.VERSION.indexOf('4') !== 0
-      ? (wdioV4 = false)
-      : (wdioV4 = true);
+    (!webdriverio.VERSION || webdriverio.VERSION.indexOf('4') !== 0) ? wdioV4 = false : wdioV4 = true;
   }
 
   _validateConfig(config) {
@@ -181,10 +179,7 @@ class Appium extends Webdriver {
     config = Object.assign(defaults, config);
 
     config.baseUrl = config.url || config.baseUrl;
-    if (
-      config.desiredCapabilities
-      && Object.keys(config.desiredCapabilities).length
-    ) {
+    if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {
       config.capabilities = config.desiredCapabilities;
     }
 
@@ -214,25 +209,21 @@ class Appium extends Webdriver {
   }
 
   static _config() {
-    return [
-      {
-        name: 'app',
-        message: 'Application package. Path to file or url',
-        default: 'http://localhost',
-      },
-      {
-        name: 'platform',
-        message: 'Mobile Platform',
-        type: 'list',
-        choices: ['iOS', 'Android'],
-        default: 'Android',
-      },
-      {
-        name: 'device',
-        message: 'Device to run tests on',
-        default: 'emulator',
-      },
-    ];
+    return [{
+      name: 'app',
+      message: 'Application package. Path to file or url',
+      default: 'http://localhost',
+    }, {
+      name: 'platform',
+      message: 'Mobile Platform',
+      type: 'list',
+      choices: ['iOS', 'Android'],
+      default: 'Android',
+    }, {
+      name: 'device',
+      message: 'Device to run tests on',
+      default: 'emulator',
+    }];
   }
 
   async _startBrowser() {
@@ -255,19 +246,13 @@ class Appium extends Webdriver {
       await this.defineTimeout(this.options.timeouts);
     }
     if (this.options.windowSize === 'maximize' && !this.platform) {
-      const res = await this.browser.execute(
-        'return [screen.width, screen.height]',
-      );
+      const res = await this.browser.execute('return [screen.width, screen.height]');
       return this.browser.windowHandleSize({
         width: res.value[0],
         height: res.value[1],
       });
     }
-    if (
-      this.options.windowSize
-      && this.options.windowSize.indexOf('x') > 0
-      && !this.platform
-    ) {
+    if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0 && !this.platform) {
       const dimensions = this.options.windowSize.split('x');
       await this.browser.windowHandleSize({
         width: dimensions[0],
@@ -418,11 +403,7 @@ class Appium extends Webdriver {
 
     const res = fn();
 
-    recorder.add(
-      'restore from Web session',
-      () => recorder.session.restore(),
-      true,
-    );
+    recorder.add('restore from Web session', () => recorder.session.restore(), true);
     return recorder.promise();
   }
 
@@ -517,9 +498,7 @@ class Appium extends Webdriver {
 
     return axios({
       method: 'post',
-      url: `${this._buildAppiumEndpoint()}/session/${
-        this.browser.sessionId
-      }/appium/device/remove_app`,
+      url: `${this._buildAppiumEndpoint()}/session/${this.browser.sessionId}/appium/device/remove_app`,
       data: { appId, bundleId },
     });
   }
@@ -537,9 +516,7 @@ class Appium extends Webdriver {
   async seeCurrentActivityIs(currentActivity) {
     onlyForApps.call(this, 'Android');
     const res = await this.browser.getCurrentActivity();
-    return truth('current activity', `to be ${currentActivity}`).assert(
-      res === currentActivity,
-    );
+    return truth('current activity', `to be ${currentActivity}`).assert(res === currentActivity);
   }
 
   /**
@@ -595,15 +572,11 @@ class Appium extends Webdriver {
 
     const res = await axios({
       method: 'get',
-      url: `${this._buildAppiumEndpoint()}/session/${
-        this.browser.sessionId
-      }/orientation`,
+      url: `${this._buildAppiumEndpoint()}/session/${this.browser.sessionId}/orientation`,
     });
 
     currentOrientation = res.data.value;
-    return truth('orientation', `to be ${orientation}`).assert(
-      currentOrientation === orientation,
-    );
+    return truth('orientation', `to be ${orientation}`).assert(currentOrientation === orientation);
   }
 
   /**
@@ -626,9 +599,7 @@ class Appium extends Webdriver {
 
     return axios({
       method: 'post',
-      url: `${this._buildAppiumEndpoint()}/session/${
-        this.browser.sessionId
-      }/orientation`,
+      url: `${this._buildAppiumEndpoint()}/session/${this.browser.sessionId}/orientation`,
       data: { orientation },
     });
   }
@@ -764,9 +735,7 @@ class Appium extends Webdriver {
       if (contexts[idx].match(/^WEBVIEW/)) return this._switchToContext(contexts[idx]);
     }
 
-    throw new Error(
-      'No WEBVIEW could be guessed, please specify one in params',
-    );
+    throw new Error('No WEBVIEW could be guessed, please specify one in params');
   }
 
   /**
@@ -957,10 +926,7 @@ class Appium extends Webdriver {
     onlyForApps.call(this);
     const res = await this.browser.$(parseLocator.call(this, locator));
     // if (!res.length) throw new ElementNotFound(locator, 'was not found in UI');
-    return this.performSwipe(await res.getLocation(), {
-      x: (await res.getLocation().x) + xoffset,
-      y: (await res.getLocation().y) + yoffset,
-    });
+    return this.performSwipe(await res.getLocation(), { x: await res.getLocation().x + xoffset, y: await res.getLocation().y + yoffset });
   }
 
   /**
@@ -976,23 +942,18 @@ class Appium extends Webdriver {
    * Appium: support Android and iOS
    */
   async performSwipe(from, to) {
-    await this.browser.touchPerform([
-      {
-        action: 'press',
-        options: from,
-      },
-      {
-        action: 'wait',
-        options: { ms: 1000 },
-      },
-      {
-        action: 'moveTo',
-        options: to,
-      },
-      {
-        action: 'release',
-      },
-    ]);
+    await this.browser.touchPerform([{
+      action: 'press',
+      options: from,
+    }, {
+      action: 'wait',
+      options: { ms: 1000 },
+    }, {
+      action: 'moveTo',
+      options: to,
+    }, {
+      action: 'release',
+    }]);
     await this.browser.pause(1000);
   }
 
@@ -1125,14 +1086,7 @@ class Appium extends Webdriver {
    *
    * Appium: support Android and iOS
    */
-  async swipeTo(
-    searchableLocator,
-    scrollLocator,
-    direction,
-    timeout,
-    offset,
-    speed,
-  ) {
+  async swipeTo(searchableLocator, scrollLocator, direction, timeout, offset, speed) {
     onlyForApps.call(this);
     direction = direction || 'down';
     switch (direction) {
@@ -1155,44 +1109,29 @@ class Appium extends Webdriver {
     const browser = this.browser;
     let err = false;
     let currentSource;
-    return browser
-      .waitUntil(
-        () => {
-          if (err) {
-            return new Error(
-              `Scroll to the end and element ${searchableLocator} was not found`,
-            );
+    return browser.waitUntil(() => {
+      if (err) {
+        return new Error(`Scroll to the end and element ${searchableLocator} was not found`);
+      }
+      return browser.$$(parseLocator.call(this, searchableLocator))
+        .then(els => els.length && els[0].isDisplayed())
+        .then((res) => {
+          if (res) {
+            return true;
           }
-          return browser
-            .$$(parseLocator.call(this, searchableLocator))
-            .then((els) => els.length && els[0].isDisplayed())
-            .then((res) => {
-              if (res) {
-                return true;
-              }
-              return this[direction](scrollLocator, offset, speed)
-                .getSource()
-                .then((source) => {
-                  if (source === currentSource) {
-                    err = true;
-                  } else {
-                    currentSource = source;
-                    return false;
-                  }
-                });
-            });
-        },
-        timeout * 1000,
-        errorMsg,
-      )
+          return this[direction](scrollLocator, offset, speed).getSource().then((source) => {
+            if (source === currentSource) {
+              err = true;
+            } else {
+              currentSource = source;
+              return false;
+            }
+          });
+        });
+    }, timeout * 1000, errorMsg)
       .catch((e) => {
         if (e.message.indexOf('timeout') && e.type !== 'NoSuchElement') {
-          throw new AssertionFailedError(
-            {
-              customMessage: `Scroll to the end and element ${searchableLocator} was not found`,
-            },
-            '',
-          );
+          throw new AssertionFailedError({ customMessage: `Scroll to the end and element ${searchableLocator} was not found` }, '');
         } else {
           throw e;
         }
@@ -1243,7 +1182,7 @@ class Appium extends Webdriver {
    */
   async pullFile(path, dest) {
     onlyForApps.call(this);
-    return this.browser.pullFile(path).then((res) => fs.writeFile(dest, Buffer.from(res, 'base64'), (err) => {
+    return this.browser.pullFile(path).then(res => fs.writeFile(dest, Buffer.from(res, 'base64'), (err) => {
       if (err) {
         return false;
       }
@@ -1349,10 +1288,7 @@ class Appium extends Webdriver {
    */
   async click(locator, context) {
     if (this.isWeb) return super.click(locator, context);
-    return super.click(
-      parseLocator.call(this, locator),
-      parseLocator.call(this, context),
-    );
+    return super.click(parseLocator.call(this, locator), parseLocator.call(this, context));
   }
 
   /**
@@ -1469,9 +1405,7 @@ class Appium extends Webdriver {
    */
   async selectOption(select, option) {
     if (this.isWeb) return super.selectOption(select, option);
-    throw new Error(
-      "Should be used only in Web context. In native context use 'click' method instead",
-    );
+    throw new Error('Should be used only in Web context. In native context use \'click\' method instead');
   }
 
   /**
@@ -1549,16 +1483,8 @@ function parseLocator(locator) {
   }
 
   locator = new Locator(locator, 'xpath');
-  if (locator.type === 'css' && !this.isWeb) {
-    throw new Error(
-      'Unable to use css locators in apps. Locator strategies for this request: xpath, id, class name or accessibility id',
-    );
-  }
-  if (locator.type === 'name' && !this.isWeb) {
-    throw new Error(
-      "Can't locate element by name in Native context. Use either ID, class name or accessibility id",
-    );
-  }
+  if (locator.type === 'css' && !this.isWeb) throw new Error('Unable to use css locators in apps. Locator strategies for this request: xpath, id, class name or accessibility id');
+  if (locator.type === 'name' && !this.isWeb) throw new Error("Can't locate element by name in Native context. Use either ID, class name or accessibility id");
   if (locator.type === 'id' && !this.isWeb && this.platform === 'android') return `//*[@resource-id='${locator.value}']`;
   return locator.simplify();
 }
@@ -1580,9 +1506,7 @@ function onlyForApps(expectedPlatform) {
       throw new Error(`${callerName} method can be used only with apps`);
     }
   } else if (this.platform !== expectedPlatform.toLowerCase()) {
-    throw new Error(
-      `${callerName} method can be used only with ${expectedPlatform} apps`,
-    );
+    throw new Error(`${callerName} method can be used only with ${expectedPlatform} apps`);
   }
 }
 

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -136,7 +136,9 @@ class Appium extends Webdriver {
     this.isRunning = false;
 
     webdriverio = requireg('webdriverio');
-    (!webdriverio.VERSION || webdriverio.VERSION.indexOf('4') !== 0) ? wdioV4 = false : wdioV4 = true;
+    !webdriverio.VERSION || webdriverio.VERSION.indexOf('4') !== 0
+      ? (wdioV4 = false)
+      : (wdioV4 = true);
   }
 
   _validateConfig(config) {
@@ -179,7 +181,10 @@ class Appium extends Webdriver {
     config = Object.assign(defaults, config);
 
     config.baseUrl = config.url || config.baseUrl;
-    if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {
+    if (
+      config.desiredCapabilities
+      && Object.keys(config.desiredCapabilities).length
+    ) {
       config.capabilities = config.desiredCapabilities;
     }
 
@@ -209,21 +214,25 @@ class Appium extends Webdriver {
   }
 
   static _config() {
-    return [{
-      name: 'app',
-      message: 'Application package. Path to file or url',
-      default: 'http://localhost',
-    }, {
-      name: 'platform',
-      message: 'Mobile Platform',
-      type: 'list',
-      choices: ['iOS', 'Android'],
-      default: 'Android',
-    }, {
-      name: 'device',
-      message: 'Device to run tests on',
-      default: 'emulator',
-    }];
+    return [
+      {
+        name: 'app',
+        message: 'Application package. Path to file or url',
+        default: 'http://localhost',
+      },
+      {
+        name: 'platform',
+        message: 'Mobile Platform',
+        type: 'list',
+        choices: ['iOS', 'Android'],
+        default: 'Android',
+      },
+      {
+        name: 'device',
+        message: 'Device to run tests on',
+        default: 'emulator',
+      },
+    ];
   }
 
   async _startBrowser() {
@@ -246,13 +255,19 @@ class Appium extends Webdriver {
       await this.defineTimeout(this.options.timeouts);
     }
     if (this.options.windowSize === 'maximize' && !this.platform) {
-      const res = await this.browser.execute('return [screen.width, screen.height]');
+      const res = await this.browser.execute(
+        'return [screen.width, screen.height]',
+      );
       return this.browser.windowHandleSize({
         width: res.value[0],
         height: res.value[1],
       });
     }
-    if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0 && !this.platform) {
+    if (
+      this.options.windowSize
+      && this.options.windowSize.indexOf('x') > 0
+      && !this.platform
+    ) {
       const dimensions = this.options.windowSize.split('x');
       await this.browser.windowHandleSize({
         width: dimensions[0],
@@ -300,7 +315,6 @@ class Appium extends Webdriver {
     // Build path to Appium REST API endpoint
     return `${protocol}://${hostname}:${port}${path}`;
   }
-
 
   /**
    * Execute code only on iOS
@@ -404,7 +418,11 @@ class Appium extends Webdriver {
 
     const res = fn();
 
-    recorder.add('restore from Web session', () => recorder.session.restore(), true);
+    recorder.add(
+      'restore from Web session',
+      () => recorder.session.restore(),
+      true,
+    );
     return recorder.promise();
   }
 
@@ -429,7 +447,6 @@ class Appium extends Webdriver {
 
     fn();
   }
-
 
   /**
    * Check if an app is installed.
@@ -500,7 +517,9 @@ class Appium extends Webdriver {
 
     return axios({
       method: 'post',
-      url: `${this._buildAppiumEndpoint()}/session/${this.browser.sessionId}/appium/device/remove_app`,
+      url: `${this._buildAppiumEndpoint()}/session/${
+        this.browser.sessionId
+      }/appium/device/remove_app`,
       data: { appId, bundleId },
     });
   }
@@ -518,7 +537,9 @@ class Appium extends Webdriver {
   async seeCurrentActivityIs(currentActivity) {
     onlyForApps.call(this, 'Android');
     const res = await this.browser.getCurrentActivity();
-    return truth('current activity', `to be ${currentActivity}`).assert(res === currentActivity);
+    return truth('current activity', `to be ${currentActivity}`).assert(
+      res === currentActivity,
+    );
   }
 
   /**
@@ -574,11 +595,15 @@ class Appium extends Webdriver {
 
     const res = await axios({
       method: 'get',
-      url: `${this._buildAppiumEndpoint()}/session/${this.browser.sessionId}/orientation`,
+      url: `${this._buildAppiumEndpoint()}/session/${
+        this.browser.sessionId
+      }/orientation`,
     });
 
     currentOrientation = res.data.value;
-    return truth('orientation', `to be ${orientation}`).assert(currentOrientation === orientation);
+    return truth('orientation', `to be ${orientation}`).assert(
+      currentOrientation === orientation,
+    );
   }
 
   /**
@@ -601,7 +626,9 @@ class Appium extends Webdriver {
 
     return axios({
       method: 'post',
-      url: `${this._buildAppiumEndpoint()}/session/${this.browser.sessionId}/orientation`,
+      url: `${this._buildAppiumEndpoint()}/session/${
+        this.browser.sessionId
+      }/orientation`,
       data: { orientation },
     });
   }
@@ -737,7 +764,9 @@ class Appium extends Webdriver {
       if (contexts[idx].match(/^WEBVIEW/)) return this._switchToContext(contexts[idx]);
     }
 
-    throw new Error('No WEBVIEW could be guessed, please specify one in params');
+    throw new Error(
+      'No WEBVIEW could be guessed, please specify one in params',
+    );
   }
 
   /**
@@ -928,7 +957,10 @@ class Appium extends Webdriver {
     onlyForApps.call(this);
     const res = await this.browser.$(parseLocator.call(this, locator));
     // if (!res.length) throw new ElementNotFound(locator, 'was not found in UI');
-    return this.performSwipe(await res.getLocation(), { x: await res.getLocation().x + xoffset, y: await res.getLocation().y + yoffset });
+    return this.performSwipe(await res.getLocation(), {
+      x: (await res.getLocation().x) + xoffset,
+      y: (await res.getLocation().y) + yoffset,
+    });
   }
 
   /**
@@ -944,18 +976,23 @@ class Appium extends Webdriver {
    * Appium: support Android and iOS
    */
   async performSwipe(from, to) {
-    await this.browser.touchPerform([{
-      action: 'press',
-      options: from,
-    }, {
-      action: 'wait',
-      options: { ms: 1000 },
-    }, {
-      action: 'moveTo',
-      options: to,
-    }, {
-      action: 'release',
-    }]);
+    await this.browser.touchPerform([
+      {
+        action: 'press',
+        options: from,
+      },
+      {
+        action: 'wait',
+        options: { ms: 1000 },
+      },
+      {
+        action: 'moveTo',
+        options: to,
+      },
+      {
+        action: 'release',
+      },
+    ]);
     await this.browser.pause(1000);
   }
 
@@ -1088,7 +1125,14 @@ class Appium extends Webdriver {
    *
    * Appium: support Android and iOS
    */
-  async swipeTo(searchableLocator, scrollLocator, direction, timeout, offset, speed) {
+  async swipeTo(
+    searchableLocator,
+    scrollLocator,
+    direction,
+    timeout,
+    offset,
+    speed,
+  ) {
     onlyForApps.call(this);
     direction = direction || 'down';
     switch (direction) {
@@ -1111,29 +1155,44 @@ class Appium extends Webdriver {
     const browser = this.browser;
     let err = false;
     let currentSource;
-    return browser.waitUntil(() => {
-      if (err) {
-        return new Error(`Scroll to the end and element ${searchableLocator} was not found`);
-      }
-      return browser.$$(parseLocator.call(this, searchableLocator))
-        .then(els => els.length && els[0].isDisplayed())
-        .then((res) => {
-          if (res) {
-            return true;
+    return browser
+      .waitUntil(
+        () => {
+          if (err) {
+            return new Error(
+              `Scroll to the end and element ${searchableLocator} was not found`,
+            );
           }
-          return this[direction](scrollLocator, offset, speed).getSource().then((source) => {
-            if (source === currentSource) {
-              err = true;
-            } else {
-              currentSource = source;
-              return false;
-            }
-          });
-        });
-    }, timeout * 1000, errorMsg)
+          return browser
+            .$$(parseLocator.call(this, searchableLocator))
+            .then((els) => els.length && els[0].isDisplayed())
+            .then((res) => {
+              if (res) {
+                return true;
+              }
+              return this[direction](scrollLocator, offset, speed)
+                .getSource()
+                .then((source) => {
+                  if (source === currentSource) {
+                    err = true;
+                  } else {
+                    currentSource = source;
+                    return false;
+                  }
+                });
+            });
+        },
+        timeout * 1000,
+        errorMsg,
+      )
       .catch((e) => {
         if (e.message.indexOf('timeout') && e.type !== 'NoSuchElement') {
-          throw new AssertionFailedError({ customMessage: `Scroll to the end and element ${searchableLocator} was not found` }, '');
+          throw new AssertionFailedError(
+            {
+              customMessage: `Scroll to the end and element ${searchableLocator} was not found`,
+            },
+            '',
+          );
         } else {
           throw e;
         }
@@ -1184,7 +1243,7 @@ class Appium extends Webdriver {
    */
   async pullFile(path, dest) {
     onlyForApps.call(this);
-    return this.browser.pullFile(path).then(res => fs.writeFile(dest, Buffer.from(res, 'base64'), (err) => {
+    return this.browser.pullFile(path).then((res) => fs.writeFile(dest, Buffer.from(res, 'base64'), (err) => {
       if (err) {
         return false;
       }
@@ -1290,7 +1349,10 @@ class Appium extends Webdriver {
    */
   async click(locator, context) {
     if (this.isWeb) return super.click(locator, context);
-    return super.click(parseLocator.call(this, locator), parseLocator.call(this, context));
+    return super.click(
+      parseLocator.call(this, locator),
+      parseLocator.call(this, context),
+    );
   }
 
   /**
@@ -1318,7 +1380,6 @@ class Appium extends Webdriver {
     if (this.isWeb) return super.dontSeeInField(field, value);
     return super.dontSeeInField(parseLocator.call(this, field), value);
   }
-
 
   /**
    * {{> dontSee }}
@@ -1408,7 +1469,9 @@ class Appium extends Webdriver {
    */
   async selectOption(select, option) {
     if (this.isWeb) return super.selectOption(select, option);
-    throw new Error('Should be used only in Web context. In native context use \'click\' method instead');
+    throw new Error(
+      "Should be used only in Web context. In native context use 'click' method instead",
+    );
   }
 
   /**
@@ -1457,7 +1520,11 @@ function parseLocator(locator) {
     }
 
     if (locator.android && this.platform === 'android') {
-      return parseLocator.call(this, locator.android);
+      if (typeof locator.android === 'string') {
+        return parseLocator.call(this, locator.android);
+      }
+      // The locator is an Android DataMatcher or ViewMatcher locator so return as is
+      return locator;
     }
 
     if (locator.ios && this.platform === 'ios') {
@@ -1472,14 +1539,26 @@ function parseLocator(locator) {
       // hook before webdriverio supports native # locators
       return parseLocator.call(this, { id: locator.slice(1) });
     }
+
     if (this.platform === 'android' && !this.isWeb) {
-      return `android=new UiSelector().text("${locator}")`;
+      const isNativeLocator = /^\-?android=?/.exec(locator);
+      return isNativeLocator
+        ? locator
+        : `android=new UiSelector().text("${locator}")`;
     }
   }
 
   locator = new Locator(locator, 'xpath');
-  if (locator.type === 'css' && !this.isWeb) throw new Error('Unable to use css locators in apps. Locator strategies for this request: xpath, id, class name or accessibility id');
-  if (locator.type === 'name' && !this.isWeb) throw new Error("Can't locate element by name in Native context. Use either ID, class name or accessibility id");
+  if (locator.type === 'css' && !this.isWeb) {
+    throw new Error(
+      'Unable to use css locators in apps. Locator strategies for this request: xpath, id, class name or accessibility id',
+    );
+  }
+  if (locator.type === 'name' && !this.isWeb) {
+    throw new Error(
+      "Can't locate element by name in Native context. Use either ID, class name or accessibility id",
+    );
+  }
   if (locator.type === 'id' && !this.isWeb && this.platform === 'android') return `//*[@resource-id='${locator.value}']`;
   return locator.simplify();
 }
@@ -1501,7 +1580,9 @@ function onlyForApps(expectedPlatform) {
       throw new Error(`${callerName} method can be used only with apps`);
     }
   } else if (this.platform !== expectedPlatform.toLowerCase()) {
-    throw new Error(`${callerName} method can be used only with ${expectedPlatform} apps`);
+    throw new Error(
+      `${callerName} method can be used only with ${expectedPlatform} apps`,
+    );
   }
 }
 

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -309,13 +309,32 @@ describe('utils', () => {
     it('returns the joined filename for filename only', () => {
       const _path = utils.screenshotOutputFolder('screenshot1.failed.png');
       _path.should.eql(
-        '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace('/', path.sep),
+        '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace(
+          /\//g,
+          path.sep,
+        ),
       );
     });
 
     it('returns the given filename for absolute one', () => {
-      const _path = utils.screenshotOutputFolder('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png');
-      _path.should.eql('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace('/', path.sep));
+      const _path = utils.screenshotOutputFolder(
+        '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace(
+          /\//g,
+          path.sep,
+        ),
+      );
+      if (os.platform() === 'win32') {
+        _path.should.eql(
+          path.resolve(
+            global.codecept_dir,
+            '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png',
+          ),
+        );
+      } else {
+        _path.should.eql(
+          '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png',
+        );
+      }
     });
   });
 });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const os = require('os');
+const path = require('path');
 const sinon = require('sinon');
 
 const utils = require('../../lib/utils');
@@ -307,12 +308,14 @@ describe('utils', () => {
 
     it('returns the joined filename for filename only', () => {
       const _path = utils.screenshotOutputFolder('screenshot1.failed.png');
-      _path.should.eql('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png');
+      _path.should.eql(
+        '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace('/', path.sep),
+      );
     });
 
     it('returns the given filename for absolute one', () => {
       const _path = utils.screenshotOutputFolder('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png');
-      _path.should.eql('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png');
+      _path.should.eql('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace('/', path.sep));
     });
   });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently, appium helper does not work with android native locator so this pr is made to resolve #2428 
- Update doc for android typo
- Update FileHelper unit test to work correctly on windows platform

Applicable helpers:
- [X] Appium

## Type of change

- [x] :rocket: New functionality
- [x] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
