### PR TITLE
chore: jsdoc color param optional in `I.say`

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -44,7 +44,7 @@ module.exports = function (obj) {
   /**
    * add print comment method`
    * @param {string} msg
-   * @param {string} color
+   * @param {string} [color]
    * @return {Promise<any> | undefined}
    * @inner
    */


### PR DESCRIPTION
minor thing but color param in `I.say` is required in typings