### PR TITLE
tests(step-log): Custom pretty logs for method args

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -112,6 +112,8 @@ class Step {
         return '*****';
       } else if (arg.toString && arg.toString() !== '[object Object]') {
         return arg.toString();
+      } else if (typeof arg === 'object' && arg.humanizeArgs) {
+        return arg.humanizeArgs();
       } else if (typeof arg === 'object') {
         return JSON.stringify(arg);
       }

--- a/lib/step.js
+++ b/lib/step.js
@@ -112,8 +112,6 @@ class Step {
         return '*****';
       } else if (arg.toString && arg.toString() !== '[object Object]') {
         return arg.toString();
-      } else if (typeof arg === 'object' && arg.humanizeArgs) {
-        return arg.humanizeArgs();
       } else if (typeof arg === 'object') {
         return JSON.stringify(arg);
       }

--- a/test/data/sandbox/configs/pageObjects/codecept.logs.json
+++ b/test/data/sandbox/configs/pageObjects/codecept.logs.json
@@ -1,0 +1,16 @@
+{
+  "tests": "./*_test.logs.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+    "CustomHelper": {
+      "require": "./customHelper.js"
+    }
+  },
+  "include": {
+    "LogsPage": "./pages/logs_page.js"
+  },
+  "bootstrap": false,
+  "mocha": {},
+  "name": "sandbox"
+}

--- a/test/data/sandbox/configs/pageObjects/customHelper.js
+++ b/test/data/sandbox/configs/pageObjects/customHelper.js
@@ -1,6 +1,14 @@
-// const Helper = require('../../lib/helper');
+const event = require('../../../../../lib/event');
 
 class CustomHelper extends Helper {
+  constructor(config) {
+    super(config);
+
+    event.dispatcher.on(event.step.started, (step) => {
+      console.log(`Start event step: ${step.toString()}`);
+    });
+  }
+
   printMessage(s) {
     // this.debug('Print message from CustomHelper');
     console.log(s);
@@ -8,6 +16,10 @@ class CustomHelper extends Helper {
 
   getHumanizeArgs(objectArgs) {
     console.log(objectArgs.value);
+  }
+
+  errorMethodHumanizeArgs(objectArgs) {
+    throw new Error('Error humanize args');
   }
 }
 

--- a/test/data/sandbox/configs/pageObjects/customHelper.js
+++ b/test/data/sandbox/configs/pageObjects/customHelper.js
@@ -5,6 +5,10 @@ class CustomHelper extends Helper {
     // this.debug('Print message from CustomHelper');
     console.log(s);
   }
+
+  getHumanizeArgs(objectArgs) {
+    console.log(objectArgs.value);
+  }
 }
 
 module.exports = CustomHelper;

--- a/test/data/sandbox/configs/pageObjects/fs_test.logs.js
+++ b/test/data/sandbox/configs/pageObjects/fs_test.logs.js
@@ -1,8 +1,9 @@
-const fs = require('fs');
-const path = require('path');
-
 Feature('Filesystem');
 
 Scenario('Print correct arg message', ({ I, LogsPage }) => {
   I.getHumanizeArgs(LogsPage);
+});
+
+Scenario('Error print correct arg message', ({ I, LogsPage }) => {
+  I.errorMethodHumanizeArgs(LogsPage);
 });

--- a/test/data/sandbox/configs/pageObjects/fs_test.logs.js
+++ b/test/data/sandbox/configs/pageObjects/fs_test.logs.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+
+Feature('Filesystem');
+
+Scenario('Print correct arg message', ({ I, LogsPage }) => {
+  I.getHumanizeArgs(LogsPage);
+});

--- a/test/data/sandbox/configs/pageObjects/pages/logs_page.js
+++ b/test/data/sandbox/configs/pageObjects/pages/logs_page.js
@@ -10,7 +10,7 @@ module.exports = {
     I.printMessage('Logs Page Message');
   },
 
-  humanizeArgs() {
+  toString() {
     return this.value;
   },
 };

--- a/test/data/sandbox/configs/pageObjects/pages/logs_page.js
+++ b/test/data/sandbox/configs/pageObjects/pages/logs_page.js
@@ -1,0 +1,16 @@
+let I;
+
+module.exports = {
+  _init() {
+    I = actor();
+    this.value = 'Logs Page Value';
+  },
+
+  print(arg) {
+    I.printMessage('Logs Page Message');
+  },
+
+  humanizeArgs() {
+    return this.value;
+  },
+};

--- a/test/runner/pageobject_test.js
+++ b/test/runner/pageobject_test.js
@@ -61,6 +61,15 @@ describe('CodeceptJS PageObject', () => {
         done();
       });
     });
+
+    it('should inject page objects by class which nested base clas', (done) => {
+      exec(`${config_run_config('codecept.logs.json')} --steps`, (err, stdout) => {
+        expect(stdout).toContain('I get humanize args Logs Page Value');
+        expect(stdout).toContain('OK  | 1 passed');
+        expect(err).toBeFalsy();
+        done();
+      });
+    });
   });
 
   describe('Show MetaSteps in Log', () => {

--- a/test/runner/pageobject_test.js
+++ b/test/runner/pageobject_test.js
@@ -62,11 +62,21 @@ describe('CodeceptJS PageObject', () => {
       });
     });
 
-    it('should inject page objects by class which nested base clas', (done) => {
-      exec(`${config_run_config('codecept.logs.json')} --steps`, (err, stdout) => {
+    it('should print pretty step log and pretty event log', (done) => {
+      exec(`${config_run_config('codecept.logs.json', 'Print correct arg message')} --steps`, (err, stdout) => {
         expect(stdout).toContain('I get humanize args Logs Page Value');
+        expect(stdout).toContain('Start event step: I get humanize args Logs Page Valu');
         expect(stdout).toContain('OK  | 1 passed');
         expect(err).toBeFalsy();
+        done();
+      });
+    });
+
+    it('should print pretty failed step log on stack trace', (done) => {
+      exec(`${config_run_config('codecept.logs.json', 'Error print correct arg message')} --steps`, (err, stdout) => {
+        expect(stdout).toContain('I.errorMethodHumanizeArgs(Logs Page Value)');
+        expect(stdout).toContain('FAIL  | 0 passed, 1 failed');
+        expect(err).toBeTruthy();
         done();
       });
     });


### PR DESCRIPTION
If helper method gets args of object type, our logs become not readable. Like: 
```js
I wait for visible { property: 'value', ... }
```

This MR adds a feature which allows pass args with custom parse-function for print pretty args. Example:
Create function `humanizeArgs` which return some string from your value or your data. 
```js
// PageObject.js
module.exports = {
  _init() {
    this.value = 'Logs Page Value';
  },

  humanizeArgs() {
    return this.value;
  },
};
```

In Custom Helper creates function which gets object with some value.
```js
// CustomHelper.js
class CustomHelper extends Helper {
  getHumanizeArgs(objectArgs) {
    console.log(objectArgs.value);
  }
}

module.exports = CustomHelper;
```
And call this custom method on your scenario
```js
// Scenario.test.js
Feature('Filesystem');

Scenario('Print correct arg message', ({ I, LogsPage }) => {
  I.getHumanizeArgs(LogsPage);
});
```

In result we will get pretty console log, like:
```js
I get humanize args Logs Page Value
```

Instead:
```js
I get humanize args {\"value\":\"Logs Page Value\"}
```